### PR TITLE
feat: support the severity threshold input

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,7 @@ jobs:
 | controls | The security control(s) to scan the files against. Multiple controls can be specified separated by a comma with no spaces. Example - `Configured liveness probe,Pods in default namespace`. Run `kubescape list controls` with the [Kubescape CLI](https://hub.armo.cloud/docs/installing-kubescape) to get a list of all controls. The complete control name can be specified or the ID such as `C-0001` can be specified. Either controls have to be specified or frameworks. | No |
 | account | Account-id for the [kubescape cloud](https://cloud.armosec.io/). Used for custom configuration, such as frameworks, control configuration, etc. | No |
 | failedThreshold | Failure threshold is the percent above which the command fails and returns exit code 1 (default 0 i.e, action fails if any control fails) | No (default 0) |
-| thresholdCritical |Threshold Critical is the number or more of critical controls that failed  and returns exit code 1 | No |
-| thresholdHigh |Threshold High is the number or more of high controls that failed and returns exit code 1 | No |
-| thresholdMedium |Threshold Medium is the number or more of medium controls that failed and returns exit code 1 | No |
-| thresholdLow |Threshold Low is the number or more of low controls that failed and returns exit code 1 | No |
+| severityThreshold | Severity threshold is the severity of a failed control at or above which the command terminates with an exit code 1 (default is `high`, i.e. the action fails if any High severity control fails) | No |
 
 ## Examples
 
@@ -155,7 +152,7 @@ jobs:
 ```
 #### Fail Kubescape scanning based on severity-threshold
 
-Scan repository with Kubescape and failed action if the number of failed resources with severity {X} is more than threshold {X}
+Scan repository with Kubescape and fail the action if the scan found failed controls with severity of Medium and above.
 
 ```yaml
 name: Kubescape scanning for misconfigurations
@@ -167,9 +164,7 @@ jobs:
       - uses: action/checkout@v3
       - uses: kubescape/github-action@main
         with:
-          thresholdCritical: 1
-          thresholdHigh: 5
-          thresholdMedium: 10
+          severityThreshold: medium
       - name: Archive kubescape scan results
         uses: actions/upload-artifact@v2
         with:

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,13 @@ inputs:
       Failure threshold is the percent above which the command fails and 
       returns exit code 1 (default 0 i.e, action fails if any control fails)
     required: false
+  severityThreshold:
+    description: |
+      Severity threshold is the severity of a failed control at or above which
+      the command terminates with an exit code 1 (default is "high", i.e. the
+      action fails if any High severity control fails)
+    required: false
+    default: high
   files:
     description: |
       Path to the configuration yaml to scan
@@ -24,28 +31,8 @@ inputs:
     required: false
   account:
     description: |
-      Account-id for the SAS.
+      Account ID for the Kubescape SaaS.
       Used for custom configuration, such as frameworks, control configuration, etc.
-    required: false
-  thresholdCritical:
-    description: |
-      Threshold Critical is the number or more of critical controls that failed 
-      and returns exit code 1
-    required: false
-  thresholdHigh:
-    description: |
-      Threshold High is the number or more of high controls that failed 
-      and returns exit code 1
-    required: false
-  thresholdMedium:
-    description: |
-      Threshold Medium is the number or more of medium controls that failed 
-      and returns exit code 1
-    required: false
-  thresholdLow:
-    description: |
-      Threshold Low is the number or more of low controls that failed 
-      and returns exit code 1
     required: false
   format:
     description: |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,16 +21,19 @@ if [ ! -z "$INPUT_CONTROLS" ]; then
     CONTROLS=$(echo "${CONTROLS%?}")
 fi
 
+# Subcommands
 FRAMEWORKS_CMD=$([ ! -z "$INPUT_FRAMEWORKS" ] && echo "framework $INPUT_FRAMEWORKS" || echo "")
 CONTROLS_CMD=$([ ! -z "$INPUT_CONTROLS" ] && echo control $CONTROLS || echo "")
-FILES=$([ ! -z "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
-ACCOUNT_CMD=$([ ! -z "$INPUT_ACCOUNT" ] && echo --account $INPUT_ACCOUNT --submit || echo "")
-INPUT_FAILEDTHRESHOLD=$([ ! -z "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold $INPUT_FAILEDTHRESHOLD || echo "")
-THRESHOLD_CRITICAL_CMD=$([ ! -z "$INPUT_THRESHOLDCRITICAL" ] && echo --threshold-critical $INPUT_THRESHOLDCRITICAL || echo "")
-THRESHOLD_HIGH_CMD=$([ ! -z "$INPUT_THRESHOLDHIGH" ] && echo --threshold-high $INPUT_THRESHOLDHIGH || echo "")
-THRESHOLD_MEDIUM_CMD=$([ ! -z "$INPUT_THRESHOLDMEDIUM" ] && echo --threshold-medium $INPUT_THRESHOLDMEDIUM || echo "")
-THRESHOLD_LOW_CMD=$([ ! -z "$INPUT_THRESHOLDLOW" ] && echo --threshold-low $INPUT_THRESHOLDLOW || echo "")
 
-COMMAND="kubescape scan $FRAMEWORKS_CMD $CONTROLS_CMD $FILES $ACCOUNT_CMD $INPUT_FAILEDTHRESHOLD $THRESHOLD_CRITICAL_CMD $THRESHOLD_HIGH_CMD $THRESHOLD_MEDIUM_CMD $THRESHOLD_LOW_CMD --format $INPUT_FORMAT --output results"
+# Output files
+FILES=$([ ! -z "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
+
+# Command-line options
+ACCOUNT_OPT=$([ ! -z "$INPUT_ACCOUNT" ] && echo --account $INPUT_ACCOUNT --submit || echo "")
+
+FAIL_THRESHOLD_OPT=$([ ! -z "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold $INPUT_FAILEDTHRESHOLD || echo "")
+SEVERITY_THRESHOLD_OPT=$([ ! -z "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-threshold $INPUT_SEVERITYTHRESHOLD || echo "")
+
+COMMAND="kubescape scan $FRAMEWORKS_CMD $CONTROLS_CMD $FILES $ACCOUNT_OPT $FAIL_THRESHOLD_OPT $SEVERITY_THRESHOLD_OPT --format $INPUT_FORMAT --output results"
 
 eval $COMMAND


### PR DESCRIPTION
# What this PR changes?

This PR adds support for specifying the severity threshold as an input for the Github Action.

Requires kubescape/kubescape#838