### PR TITLE
Bump kubescape 2.0.183

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubescape/kubescape:v2.0.179
+FROM quay.io/kubescape/kubescape:v2.0.183
 
 # Kubescape uses root privileges for writing the results to a file
 USER root

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,9 @@ inputs:
     required: false
   format:
     description: |
-      Output format
+      Output format.
+
+      Can accept multiple comma-separated formats, e.g. "sarif,json,html"
       Run `kubescape scan -h` for listing supported formats
     required: false
     default: junit


### PR DESCRIPTION
# What this PR changes?
This PR: 
- Documents support for outputting to multiple formats.
- Bumps Kubescape to the latest version.

### Notes for the Reviewer

I will add the more extensive documentation on how to use Kubescape for autofixing PRs in the following PR, after I’m able to properly test it.