### PR TITLE
feat: support autofixing

### DIFF
--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -22,7 +22,7 @@ jobs:
 ---
 
 name: Suggest autofixes with Kubescape
-on: [push,pull_request]
+on: [pull_request]
 jobs:
   kubescape:
     runs-on: ubuntu-latest

--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -18,3 +18,39 @@ jobs:
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: results.sarif
+
+---
+
+name: Suggest autofixes with Kubescape
+on: [push,pull_request]
+jobs:
+  kubescape:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v14.6
+    - uses: kubescape/github-action@main
+      with:
+        account: ${{secrets.KUBESCAPE_ACCOUNT}}
+        files: ${{ steps.changed-files.outputs.all_changed_files }}
+        fixFiles: true
+        format: "sarif"
+    - uses: peter-evans/create-pull-request@v4
+      with:
+        add-paths: |
+          *.yaml
+        commit-message: "chore: fix K8s misconfigurations"
+        title: "[Kubescape] chore: fix K8s misconfigurations"
+        body: |
+          # What this PR changes
+
+          [Kubescape](https://github.com/kubescape/kubescape) has found misconfigurations in the targeted branch. This PR fixes the misconfigurations that have automatic fixes available.
+
+          You may still need to fix misconfigurations that do not have automatic fixes.
+        base: ${{ github.head_ref }}
+        branch: kubescape-auto-fix-${{ github.head_ref || github.ref_name }}
+        delete-branch: true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       continue-on-error: true
       with:
         format: sarif
-        outputFile: results.sarif
+        outputFile: results
         # # Optional: Specify the Kubescape cloud account ID
         # account: ${{secrets.KUBESCAPE_ACCOUNT}}
         # # Optional: Scan a specific path. Default will scan the whole repository
@@ -82,7 +82,7 @@ jobs:
 | Name | Description | Required |
 | --- | --- | ---|
 | files | YAML files or Helm charts to scan for misconfigurations. The files need to be provided with the complete path from the root of the repository. | No (default is `.` which scans the whole repository) |
-| outputFile | Name of the output file where the scan result will be stored. | No (default is `results.out`) |
+| outputFile | Name of the output file where the scan result will be stored without the extension. | No (default is `results`) |
 | frameworks | Security framework(s) to scan the files against. Multiple frameworks can be specified separated by a comma with no spaces. Example - `nsa,devopsbest`. Run `kubescape list frameworks` in the [Kubescape CLI](https://hub.armo.cloud/docs/installing-kubescape) to get a list of all frameworks. Either frameworks have to be specified or controls. | No |
 | controls | Security control(s) to scan the files against. Multiple controls can be specified separated by a comma with no spaces. Example - `Configured liveness probe,Pods in default namespace`. Run `kubescape list controls` in the [Kubescape CLI](https://hub.armo.cloud/docs/installing-kubescape) to get a list of all controls. You can use either the complete control name or the control ID such as `C-0001` to specify the control you want use. You must specify either the control(s) or the framework(s) you want used in the scan. | No |
 | account | Account ID for [Kubescape cloud](https://cloud.armosec.io/). Used for custom configuration, such as frameworks, control configuration, etc. | No |
@@ -106,7 +106,7 @@ jobs:
       continue-on-error: true
       with:
         format: sarif
-        outputFile: results.sarif
+        outputFile: results
         # Specify the Kubescape cloud account ID
         account: ${{secrets.KUBESCAPE_ACCOUNT}}
     - name: Upload Kubescape scan results to Github Code Scanning
@@ -131,7 +131,7 @@ jobs:
       continue-on-error: true
       with:
         format: sarif
-        outputFile: results.sarif
+        outputFile: results
         # Scan a specific path. Default will scan the whole repository
         files: "examples/kubernetes-manifests/*.yaml"
     - name: Upload Kubescape scan results to Github Code Scanning
@@ -156,7 +156,7 @@ jobs:
         continue-on-error: true
         with:
           format: sarif
-          outputFile: results.sarif
+          outputFile: results
           frameworks: |
             nsa,mitre
       - name: Upload Kubescape scan results to Github Code Scanning
@@ -181,7 +181,7 @@ jobs:
         continue-on-error: false
         with:
           format: sarif
-          outputFile: results.sarif
+          outputFile: results
           failedThreshold: 50
       - name: Upload Kubescape scan results to Github Code Scanning
         uses: github/codeql-action/upload-sarif@v2
@@ -204,7 +204,7 @@ jobs:
         continue-on-error: false
         with:
           format: sarif
-          outputFile: results.sarif
+          outputFile: results
           severityThreshold: medium
       - name: Upload Kubescape scan results to Github Code Scanning
         uses: github/codeql-action/upload-sarif@v2

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To make Kubescape automatically suggest fixes to your pushes and pull requests, 
 
 ```yaml
 name: Suggest autofixes with Kubescape
-on: [push,pull_request]
+on: [pull_request]
 jobs:
   kubescape:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ jobs:
         delete-branch: true
 ```
 
+Please note that since Kubescape provides automatic fixes only to the rendered YAML manifests, the workflow above will not produce correct fixes for Helm charts.
+
+The next important thing to note is that Kubescape only fixes the files. It does not open pull requests on its own. In the example above, a separate step that runs a different action opens the appropriate pull request. Due to how Github works, there are [limitations](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) on running and opening pull requests to forks. The action running in this step is maintained by its respective maintainers, and not the Kubescape team, so you should review its documentation when troubleshooting the process of triggering the workflow run and opening pull requests.
+
 ## Inputs
 
 | Name | Description | Required |

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,12 @@ inputs:
     required: false
   outputFile:
     description: |
-      Name of the output file. Default is "results.out".
+      Name of the output file, without the extension.
+
+      Default is "results".
+
+      Kubescape adds the appropriate extension automatically to support both
+      single and multiple output formats.
     required: false
   frameworks:
     description: |
@@ -42,10 +47,26 @@ inputs:
     description: |
       Output format.
 
-      Can accept multiple comma-separated formats, e.g. "sarif,json,html"
-      Run `kubescape scan -h` for listing supported formats
+      Can take one or more formats. To use one format, omit the comma, e.g
+      `format: json`. To produce results in multiple formats, separate them with
+      a comma: `format: sarif,json`.
+
+      For example, when using `output: "results"` and `format: "sarif,json"`,
+      Kubescape will produce 2 files: `results.sarif` and `results.json`. You
+      can then use `results.sarif` to publish results to Github Code Scanning
+      and `results.json` to suggest automatic fixes.
+
+      Run `kubescape scan -h` to see a list of supported formats.
     required: false
     default: junit
+  fixFiles:
+    description: |
+      Whether Kubescape will automatically fix files or not.
+
+      If enabled, Kubescape will make fixes to the input files. You can then
+      use these fixes to open Pull Requests from your CI/CD pipeline.
+    required: false
+    default: false
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 
 # Fixing files requires a JSON output file to be present
 have_json_format="false"
-if [ ! -z "$INPUT_FORMATS" ] && contains $INPUT_FORMATS "json"; then
+if [ ! -z "$INPUT_FORMAT" ] && contains $INPUT_FORMAT "json"; then
     have_json_format="true"
 fi
 
@@ -36,7 +36,7 @@ if [ "$INPUT_FIXFILES" = "true" ]; then
 fi
 
 if [ "$should_fix_files" = "true" ] && [ "$have_json_format" != "true" ]; then
-    echo 'No output in JSON format to fix files. Autofixng files requires a JSON output file to be present. Please use `format: "json[,OTHER_FORMATS]`'
+    echo 'No output in JSON format to fix files. Autofixing files requires a JSON output file to be present. Please use `format: "json[,OTHER_FORMATS]`'
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,29 +19,29 @@ set -e
 # Declare Kubescape client
 export KS_CLIENT="github_actions"
 
-if [ -n "$INPUT_FRAMEWORKS" ] && [ -n "$INPUT_CONTROLS" ]; then
+if [ -n "${INPUT_FRAMEWORKS}" ] && [ -n "${INPUT_CONTROLS}" ]; then
     echo "Framework and Control is specified. Please specify either one of them or neither"
     exit 1
 fi
 
 # Fixing files requires a JSON output file to be present
 have_json_format="false"
-if [ -n "$INPUT_FORMAT" ] && contains "${INPUT_FORMAT}" "json"; then
+if [ -n "${INPUT_FORMAT}" ] && contains "${INPUT_FORMAT}" "json"; then
     have_json_format="true"
 fi
 
 should_fix_files="false"
-if [ "$INPUT_FIXFILES" = "true" ]; then
+if [ "${INPUT_FIXFILES}" = "true" ]; then
     should_fix_files="true"
 fi
 
-if [ "$should_fix_files" = "true" ] && [ "$have_json_format" != "true" ]; then
+if [ "${should_fix_files}" = "true" ] && [ "${have_json_format}" != "true" ]; then
     echo 'No output in JSON format to fix files. Autofixing files requires a JSON output file to be present. Please use "format: "json[,OTHER_FORMATS]"'
     exit 1
 fi
 
 # Split the controls by comma and concatenate with quotes around each control
-if [ -n "$INPUT_CONTROLS" ]; then
+if [ -n "${INPUT_CONTROLS}" ]; then
     controls=""
     set -f; IFS=','
     set -- "${INPUT_CONTROLS}"
@@ -49,31 +49,31 @@ if [ -n "$INPUT_CONTROLS" ]; then
     for control in "$@"
     do
         control=$(echo "${control}" | xargs) # Remove leading/trailing whitespaces
-        controls="$controls\"$control\","
+        controls="${controls}\"${control}\","
     done
     controls=$(echo "${controls%?}")
 fi
 
 # Subcommands
 artifacts_path="/home/ks/.kubescape"
-frameworks_cmd=$([ -n "$INPUT_FRAMEWORKS" ] && echo "framework $INPUT_FRAMEWORKS" || echo "")
-controls_cmd=$([ -n "$INPUT_CONTROLS" ] && echo control "${controls}" || echo "")
+frameworks_cmd=$([ -n "${INPUT_FRAMEWORKS}" ] && echo "framework ${INPUT_FRAMEWORKS}" || echo "")
+controls_cmd=$([ -n "${INPUT_CONTROLS}" ] && echo control "${controls}" || echo "")
 
 # Files to scan
-files=$([ -n "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
+files=$([ -n "${INPUT_FILES}" ] && echo "${INPUT_FILES}" || echo .)
 
 # Output file name
-output_file=$([ -n "$INPUT_OUTPUTFILE" ] && echo "$INPUT_OUTPUTFILE" || echo "results")
+output_file=$([ -n "${INPUT_OUTPUTFILE}" ] && echo "${INPUT_OUTPUTFILE}" || echo "results")
 
 # Command-line options
-account_opt=$([ -n "$INPUT_ACCOUNT" ] && echo --account "${INPUT_ACCOUNT}" || echo "")
+account_opt=$([ -n "${INPUT_ACCOUNT}" ] && echo --account "${INPUT_ACCOUNT}" || echo "")
 
 # If account ID is empty, we load artifacts from the local path, otherwise we
 # load from the cloud (this will enable custom framework support)
-artifacts=$([ -n "$INPUT_ACCOUNT" ] && echo "" || echo --use-artifacts-from "${artifacts_path}")
+artifacts=$([ -n "${INPUT_ACCOUNT}" ] && echo "" || echo --use-artifacts-from "${artifacts_path}")
 
-fail_threshold_opt=$([ -n "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold "${INPUT_FAILEDTHRESHOLD}" || echo "")
-severity_threshold_opt=$([ -n "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-threshold "${INPUT_SEVERITYTHRESHOLD}" || echo "")
+fail_threshold_opt=$([ -n "${INPUT_FAILEDTHRESHOLD}" ] && echo --fail-threshold "${INPUT_FAILEDTHRESHOLD}" || echo "")
+severity_threshold_opt=$([ -n "${INPUT_SEVERITYTHRESHOLD}" ] && echo --severity-threshold "${INPUT_SEVERITYTHRESHOLD}" || echo "")
 
 # `kubescape fix` requires the latest "json" format version. Other formats
 # ignore this flag.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,7 +79,7 @@ SEVERITY_THRESHOLD_OPT=$([ ! -z "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-
 # ignore this flag.
 format_version_opt="--format-version v2"
 
-SCAN_COMMAND="kubescape scan $FRAMEWORKS_CMD $CONTROLS_CMD $FILES $ACCOUNT_OPT $FAIL_THRESHOLD_OPT $SEVERITY_THRESHOLD_OPT --format $INPUT_FORMAT $format_version_opt --output $OUTPUT_FILE $ARTIFACTS"
+SCAN_COMMAND="kubescape scan $FRAMEWORKS_CMD $CONTROLS_CMD $FILES $ACCOUNT_OPT $FAIL_THRESHOLD_OPT $SEVERITY_THRESHOLD_OPT --format $INPUT_FORMAT $format_version_opt --output $OUTPUT_FILE"
 
 eval $SCAN_COMMAND
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,27 +16,11 @@ contains() {
 
 set -e
 
-# Declare Kubescape client
+# Kubescape uses the client name to make a request for checking for updates
 export KS_CLIENT="github_actions"
 
 if [ -n "${INPUT_FRAMEWORKS}" ] && [ -n "${INPUT_CONTROLS}" ]; then
     echo "Framework and Control is specified. Please specify either one of them or neither"
-    exit 1
-fi
-
-# Fixing files requires a JSON output file to be present
-have_json_format="false"
-if [ -n "${INPUT_FORMAT}" ] && contains "${INPUT_FORMAT}" "json"; then
-    have_json_format="true"
-fi
-
-should_fix_files="false"
-if [ "${INPUT_FIXFILES}" = "true" ]; then
-    should_fix_files="true"
-fi
-
-if [ "${should_fix_files}" = "true" ] && [ "${have_json_format}" != "true" ]; then
-    echo 'No output in JSON format to fix files. Autofixing files requires a JSON output file to be present. Please use "format: "json[,OTHER_FORMATS]"'
     exit 1
 fi
 
@@ -54,17 +38,30 @@ if [ -n "${INPUT_CONTROLS}" ]; then
     controls=$(echo "${controls%?}")
 fi
 
-# Subcommands
 frameworks_cmd=$([ -n "${INPUT_FRAMEWORKS}" ] && echo "framework ${INPUT_FRAMEWORKS}" || echo "")
 controls_cmd=$([ -n "${INPUT_CONTROLS}" ] && echo control "${controls}" || echo "")
 
-# Files to scan
 files=$([ -n "${INPUT_FILES}" ] && echo "${INPUT_FILES}" || echo .)
 
-# Output file name
+output_formats="${INPUT_FORMAT}"
+have_json_format="false"
+if [ -n "${output_formats}" ] && contains "${output_formats}" "json"; then
+    have_json_format="true"
+fi
+
+should_fix_files="false"
+if [ "${INPUT_FIXFILES}" = "true" ]; then
+    should_fix_files="true"
+fi
+
+# If a user requested Kubescape to fix their files, but forgot to ask for JSON
+# output, do it for them
+if [ "${should_fix_files}" = "true" ] && [ "${have_json_format}" != "true" ]; then
+    output_formats="${output_formats},json"
+fi
+
 output_file=$([ -n "${INPUT_OUTPUTFILE}" ] && echo "${INPUT_OUTPUTFILE}" || echo "results")
 
-# Command-line options
 account_opt=$([ -n "${INPUT_ACCOUNT}" ] && echo --account "${INPUT_ACCOUNT}" || echo "")
 
 # If account ID is empty, we load artifacts from the local path, otherwise we
@@ -73,13 +70,14 @@ artifacts_path="/home/ks/.kubescape"
 artifacts=$([ -n "${INPUT_ACCOUNT}" ] && echo "" || echo --use-artifacts-from "${artifacts_path}")
 
 fail_threshold_opt=$([ -n "${INPUT_FAILEDTHRESHOLD}" ] && echo --fail-threshold "${INPUT_FAILEDTHRESHOLD}" || echo "")
+
 severity_threshold_opt=$([ -n "${INPUT_SEVERITYTHRESHOLD}" ] && echo --severity-threshold "${INPUT_SEVERITYTHRESHOLD}" || echo "")
 
-# `kubescape fix` requires the latest "json" format version. Other formats
-# ignore this flag.
+# The `kubescape fix` subcommand requires the latest "json" format version.
+# Other formats ignore this flag.
 format_version_opt="--format-version v2"
 
-scan_command="kubescape scan $frameworks_cmd $controls_cmd $files $account_opt $fail_threshold_opt $severity_threshold_opt --format $INPUT_FORMAT $format_version_opt --output $output_file"
+scan_command="kubescape scan ${frameworks_cmd} ${controls_cmd} ${files} ${account_opt} ${fail_threshold_opt} ${severity_threshold_opt} --format ${output_formats} ${format_version_opt} --output ${output_file}"
 
 eval "${scan_command}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,48 +42,48 @@ fi
 
 # Split the controls by comma and concatenate with quotes around each control
 if [ -n "$INPUT_CONTROLS" ]; then
-    CONTROLS=""
+    controls=""
     set -f; IFS=','
     set -- "${INPUT_CONTROLS}"
     set +f; unset IFS
     for control in "$@"
     do
         control=$(echo "${control}" | xargs) # Remove leading/trailing whitespaces
-        CONTROLS="$CONTROLS\"$control\","
+        controls="$controls\"$control\","
     done
-    CONTROLS=$(echo "${CONTROLS%?}")
+    controls=$(echo "${controls%?}")
 fi
 
 # Subcommands
-ARTIFACTS_PATH="/home/ks/.kubescape"
-FRAMEWORKS_CMD=$([ -n "$INPUT_FRAMEWORKS" ] && echo "framework $INPUT_FRAMEWORKS" || echo "")
-CONTROLS_CMD=$([ -n "$INPUT_CONTROLS" ] && echo control "${CONTROLS}" || echo "")
+artifacts_path="/home/ks/.kubescape"
+frameworks_cmd=$([ -n "$INPUT_FRAMEWORKS" ] && echo "framework $INPUT_FRAMEWORKS" || echo "")
+controls_cmd=$([ -n "$INPUT_CONTROLS" ] && echo control "${controls}" || echo "")
 
 # Files to scan
-FILES=$([ -n "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
+files=$([ -n "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
 
 # Output file name
-OUTPUT_FILE=$([ -n "$INPUT_OUTPUTFILE" ] && echo "$INPUT_OUTPUTFILE" || echo "results")
+output_file=$([ -n "$INPUT_OUTPUTFILE" ] && echo "$INPUT_OUTPUTFILE" || echo "results")
 
 # Command-line options
-ACCOUNT_OPT=$([ -n "$INPUT_ACCOUNT" ] && echo --account "${INPUT_ACCOUNT}" || echo "")
+account_opt=$([ -n "$INPUT_ACCOUNT" ] && echo --account "${INPUT_ACCOUNT}" || echo "")
 
 # If account ID is empty, we load artifacts from the local path, otherwise we
 # load from the cloud (this will enable custom framework support)
-ARTIFACTS=$([ -n "$INPUT_ACCOUNT" ] && echo "" || echo --use-artifacts-from "${ARTIFACTS_PATH}")
+artifacts=$([ -n "$INPUT_ACCOUNT" ] && echo "" || echo --use-artifacts-from "${artifacts_path}")
 
-FAIL_THRESHOLD_OPT=$([ -n "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold "${INPUT_FAILEDTHRESHOLD}" || echo "")
-SEVERITY_THRESHOLD_OPT=$([ -n "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-threshold "${INPUT_SEVERITYTHRESHOLD}" || echo "")
+fail_threshold_opt=$([ -n "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold "${INPUT_FAILEDTHRESHOLD}" || echo "")
+severity_threshold_opt=$([ -n "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-threshold "${INPUT_SEVERITYTHRESHOLD}" || echo "")
 
 # `kubescape fix` requires the latest "json" format version. Other formats
 # ignore this flag.
 format_version_opt="--format-version v2"
 
-SCAN_COMMAND="kubescape scan $FRAMEWORKS_CMD $CONTROLS_CMD $FILES $ACCOUNT_OPT $FAIL_THRESHOLD_OPT $SEVERITY_THRESHOLD_OPT --format $INPUT_FORMAT $format_version_opt --output $OUTPUT_FILE"
+scan_command="kubescape scan $frameworks_cmd $controls_cmd $files $account_opt $fail_threshold_opt $severity_threshold_opt --format $INPUT_FORMAT $format_version_opt --output $output_file"
 
-eval "${SCAN_COMMAND}"
+eval "${scan_command}"
 
 if [ "$should_fix_files" = "true" ]; then
-    fix_command="yes | kubescape fix $OUTPUT_FILE.json"
+    fix_command="yes | kubescape fix ${output_file}.json"
     eval "${fix_command}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ account_opt=$([ -n "${INPUT_ACCOUNT}" ] && echo --account "${INPUT_ACCOUNT}" || 
 # If account ID is empty, we load artifacts from the local path, otherwise we
 # load from the cloud (this will enable custom framework support)
 artifacts_path="/home/ks/.kubescape"
-artifacts=$([ -n "${INPUT_ACCOUNT}" ] && echo "" || echo --use-artifacts-from "${artifacts_path}")
+artifacts_opt=$([ -n "${INPUT_ACCOUNT}" ] && echo "" || echo --use-artifacts-from "${artifacts_path}")
 
 fail_threshold_opt=$([ -n "${INPUT_FAILEDTHRESHOLD}" ] && echo --fail-threshold "${INPUT_FAILEDTHRESHOLD}" || echo "")
 
@@ -84,6 +84,7 @@ severity_threshold_opt=$(\
 # Other formats ignore this flag.
 format_version_opt="--format-version v2"
 
+# TODO: include artifacts_opt once https://github.com/kubescape/kubescape/issues/1040 is resolved
 scan_command="kubescape scan ${frameworks_cmd} ${controls_cmd} ${files} ${account_opt} ${fail_threshold_opt} ${severity_threshold_opt} --format ${output_formats} ${format_version_opt} --output ${output_file}"
 
 echo "${scan_command}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,43 @@
 #!/bin/sh
 
+# Checks if `string` contains `substring`.
+#
+# Arguments:
+#   String to check.
+#
+# Returns:
+#   0 if `string` contains `substring`, otherwise 1.
+contains() {
+    case "$1" in
+        *$2*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 set -e
 
-# Declear ks client  
+# Declare Kubescape client
 export KS_CLIENT="github_actions"
 
 if [ ! -z "$INPUT_FRAMEWORKS" ] && [ ! -z "$INPUT_CONTROLS" ]; then
-echo "Framework and Control is specified. Please specify either one of them or neither"
-exit 1
+    echo "Framework and Control is specified. Please specify either one of them or neither"
+    exit 1
+fi
+
+# Fixing files requires a JSON output file to be present
+have_json_format="false"
+if [ ! -z "$INPUT_FORMATS" ] && contains $INPUT_FORMATS "json"; then
+    have_json_format="true"
+fi
+
+should_fix_files="false"
+if [ "$INPUT_FIXFILES" = "true" ]; then
+    should_fix_files="true"
+fi
+
+if [ "$should_fix_files" = "true" ] && [ "$have_json_format" != "true" ]; then
+    echo 'No output in JSON format to fix files. Autofixng files requires a JSON output file to be present. Please use `format: "json[,OTHER_FORMATS]`'
+    exit 1
 fi
 
 # Split the controls by comma and concatenate with quotes around each control
@@ -33,18 +63,27 @@ CONTROLS_CMD=$([ ! -z "$INPUT_CONTROLS" ] && echo control $CONTROLS || echo "")
 FILES=$([ ! -z "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
 
 # Output file name
-OUTPUT_FILE=$([ ! -z "$INPUT_OUTPUTFILE" ] && echo "$INPUT_OUTPUTFILE" || echo "results.out")
+OUTPUT_FILE=$([ ! -z "$INPUT_OUTPUTFILE" ] && echo "$INPUT_OUTPUTFILE" || echo "results")
 
 # Command-line options
 ACCOUNT_OPT=$([ ! -z "$INPUT_ACCOUNT" ] && echo --account $INPUT_ACCOUNT || echo "")
 
-# If account ID is empty, we load artifacts from the local path, otherwise we load from the cloud (this will enable custom framework support)
+# If account ID is empty, we load artifacts from the local path, otherwise we
+# load from the cloud (this will enable custom framework support)
 ARTIFACTS=$([ ! -z "$INPUT_ACCOUNT" ] && echo "" || echo --use-artifacts-from $ARTIFACTS_PATH)
 
 FAIL_THRESHOLD_OPT=$([ ! -z "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold $INPUT_FAILEDTHRESHOLD || echo "")
 SEVERITY_THRESHOLD_OPT=$([ ! -z "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-threshold $INPUT_SEVERITYTHRESHOLD || echo "")
 
-COMMAND="kubescape scan $FRAMEWORKS_CMD $CONTROLS_CMD $FILES $ACCOUNT_OPT $FAIL_THRESHOLD_OPT $SEVERITY_THRESHOLD_OPT --format $INPUT_FORMAT --output $OUTPUT_FILE $ARTIFACTS"
+# `kubescape fix` requires the latest "json" format version. Other formats
+# ignore this flag.
+format_version_opt="--format-version v2"
 
-eval $COMMAND
+SCAN_COMMAND="kubescape scan $FRAMEWORKS_CMD $CONTROLS_CMD $FILES $ACCOUNT_OPT $FAIL_THRESHOLD_OPT $SEVERITY_THRESHOLD_OPT --format $INPUT_FORMAT $format_version_opt --output $OUTPUT_FILE $ARTIFACTS"
 
+eval $SCAN_COMMAND
+
+if [ "$should_fix_files" = "true" ]; then
+    fix_command="yes | kubescape fix $OUTPUT_FILE"
+    eval $fix_command
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,14 @@ artifacts=$([ -n "${INPUT_ACCOUNT}" ] && echo "" || echo --use-artifacts-from "$
 
 fail_threshold_opt=$([ -n "${INPUT_FAILEDTHRESHOLD}" ] && echo --fail-threshold "${INPUT_FAILEDTHRESHOLD}" || echo "")
 
-severity_threshold_opt=$([ -n "${INPUT_SEVERITYTHRESHOLD}" ] && echo --severity-threshold "${INPUT_SEVERITYTHRESHOLD}" || echo "")
+# When a user requests to fix files, the action should not fail because the
+# results exceed severity. This is subject to change in the future.
+severity_threshold_opt=$(\
+	[ -n "${INPUT_SEVERITYTHRESHOLD}" ] \
+	&& [ "${should_fix_files}" = "false" ] \
+	&& echo --severity-threshold "${INPUT_SEVERITYTHRESHOLD}" \
+	|| echo "" \
+)
 
 # The `kubescape fix` subcommand requires the latest "json" format version.
 # Other formats ignore this flag.
@@ -79,6 +86,7 @@ format_version_opt="--format-version v2"
 
 scan_command="kubescape scan ${frameworks_cmd} ${controls_cmd} ${files} ${account_opt} ${fail_threshold_opt} ${severity_threshold_opt} --format ${output_formats} ${format_version_opt} --output ${output_file}"
 
+echo "${scan_command}"
 eval "${scan_command}"
 
 if [ "$should_fix_files" = "true" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,14 +19,14 @@ set -e
 # Declare Kubescape client
 export KS_CLIENT="github_actions"
 
-if [ ! -z "$INPUT_FRAMEWORKS" ] && [ ! -z "$INPUT_CONTROLS" ]; then
+if [ -n "$INPUT_FRAMEWORKS" ] && [ -n "$INPUT_CONTROLS" ]; then
     echo "Framework and Control is specified. Please specify either one of them or neither"
     exit 1
 fi
 
 # Fixing files requires a JSON output file to be present
 have_json_format="false"
-if [ ! -z "$INPUT_FORMAT" ] && contains $INPUT_FORMAT "json"; then
+if [ -n "$INPUT_FORMAT" ] && contains $INPUT_FORMAT "json"; then
     have_json_format="true"
 fi
 
@@ -41,7 +41,7 @@ if [ "$should_fix_files" = "true" ] && [ "$have_json_format" != "true" ]; then
 fi
 
 # Split the controls by comma and concatenate with quotes around each control
-if [ ! -z "$INPUT_CONTROLS" ]; then
+if [ -n "$INPUT_CONTROLS" ]; then
     CONTROLS=""
     set -f; IFS=','
     set -- $INPUT_CONTROLS
@@ -56,24 +56,24 @@ fi
 
 # Subcommands
 ARTIFACTS_PATH="/home/ks/.kubescape"
-FRAMEWORKS_CMD=$([ ! -z "$INPUT_FRAMEWORKS" ] && echo "framework $INPUT_FRAMEWORKS" || echo "")
-CONTROLS_CMD=$([ ! -z "$INPUT_CONTROLS" ] && echo control $CONTROLS || echo "")
+FRAMEWORKS_CMD=$([ -n "$INPUT_FRAMEWORKS" ] && echo "framework $INPUT_FRAMEWORKS" || echo "")
+CONTROLS_CMD=$([ -n "$INPUT_CONTROLS" ] && echo control $CONTROLS || echo "")
 
 # Files to scan
-FILES=$([ ! -z "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
+FILES=$([ -n "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
 
 # Output file name
-OUTPUT_FILE=$([ ! -z "$INPUT_OUTPUTFILE" ] && echo "$INPUT_OUTPUTFILE" || echo "results")
+OUTPUT_FILE=$([ -n "$INPUT_OUTPUTFILE" ] && echo "$INPUT_OUTPUTFILE" || echo "results")
 
 # Command-line options
-ACCOUNT_OPT=$([ ! -z "$INPUT_ACCOUNT" ] && echo --account $INPUT_ACCOUNT || echo "")
+ACCOUNT_OPT=$([ -n "$INPUT_ACCOUNT" ] && echo --account $INPUT_ACCOUNT || echo "")
 
 # If account ID is empty, we load artifacts from the local path, otherwise we
 # load from the cloud (this will enable custom framework support)
-ARTIFACTS=$([ ! -z "$INPUT_ACCOUNT" ] && echo "" || echo --use-artifacts-from $ARTIFACTS_PATH)
+ARTIFACTS=$([ -n "$INPUT_ACCOUNT" ] && echo "" || echo --use-artifacts-from $ARTIFACTS_PATH)
 
-FAIL_THRESHOLD_OPT=$([ ! -z "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold $INPUT_FAILEDTHRESHOLD || echo "")
-SEVERITY_THRESHOLD_OPT=$([ ! -z "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-threshold $INPUT_SEVERITYTHRESHOLD || echo "")
+FAIL_THRESHOLD_OPT=$([ -n "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold $INPUT_FAILEDTHRESHOLD || echo "")
+SEVERITY_THRESHOLD_OPT=$([ -n "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-threshold $INPUT_SEVERITYTHRESHOLD || echo "")
 
 # `kubescape fix` requires the latest "json" format version. Other formats
 # ignore this flag.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,6 @@ if [ -n "${INPUT_CONTROLS}" ]; then
 fi
 
 # Subcommands
-artifacts_path="/home/ks/.kubescape"
 frameworks_cmd=$([ -n "${INPUT_FRAMEWORKS}" ] && echo "framework ${INPUT_FRAMEWORKS}" || echo "")
 controls_cmd=$([ -n "${INPUT_CONTROLS}" ] && echo control "${controls}" || echo "")
 
@@ -70,6 +69,7 @@ account_opt=$([ -n "${INPUT_ACCOUNT}" ] && echo --account "${INPUT_ACCOUNT}" || 
 
 # If account ID is empty, we load artifacts from the local path, otherwise we
 # load from the cloud (this will enable custom framework support)
+artifacts_path="/home/ks/.kubescape"
 artifacts=$([ -n "${INPUT_ACCOUNT}" ] && echo "" || echo --use-artifacts-from "${artifacts_path}")
 
 fail_threshold_opt=$([ -n "${INPUT_FAILEDTHRESHOLD}" ] && echo --fail-threshold "${INPUT_FAILEDTHRESHOLD}" || echo "")
@@ -84,6 +84,6 @@ scan_command="kubescape scan $frameworks_cmd $controls_cmd $files $account_opt $
 eval "${scan_command}"
 
 if [ "$should_fix_files" = "true" ]; then
-    fix_command="yes | kubescape fix ${output_file}.json"
+    fix_command="kubescape fix --no-confirm ${output_file}.json"
     eval "${fix_command}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,6 +84,6 @@ SCAN_COMMAND="kubescape scan $FRAMEWORKS_CMD $CONTROLS_CMD $FILES $ACCOUNT_OPT $
 eval $SCAN_COMMAND
 
 if [ "$should_fix_files" = "true" ]; then
-    fix_command="yes | kubescape fix $OUTPUT_FILE"
+    fix_command="yes | kubescape fix $OUTPUT_FILE.json"
     eval $fix_command
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 
 # Fixing files requires a JSON output file to be present
 have_json_format="false"
-if [ -n "$INPUT_FORMAT" ] && contains $INPUT_FORMAT "json"; then
+if [ -n "$INPUT_FORMAT" ] && contains "${INPUT_FORMAT}" "json"; then
     have_json_format="true"
 fi
 
@@ -36,7 +36,7 @@ if [ "$INPUT_FIXFILES" = "true" ]; then
 fi
 
 if [ "$should_fix_files" = "true" ] && [ "$have_json_format" != "true" ]; then
-    echo 'No output in JSON format to fix files. Autofixing files requires a JSON output file to be present. Please use `format: "json[,OTHER_FORMATS]`'
+    echo 'No output in JSON format to fix files. Autofixing files requires a JSON output file to be present. Please use "format: "json[,OTHER_FORMATS]"'
     exit 1
 fi
 
@@ -44,11 +44,11 @@ fi
 if [ -n "$INPUT_CONTROLS" ]; then
     CONTROLS=""
     set -f; IFS=','
-    set -- $INPUT_CONTROLS
+    set -- "${INPUT_CONTROLS}"
     set +f; unset IFS
     for control in "$@"
     do
-        control=$(echo $control | xargs) # Remove leading/trailing whitespaces
+        control=$(echo "${control}" | xargs) # Remove leading/trailing whitespaces
         CONTROLS="$CONTROLS\"$control\","
     done
     CONTROLS=$(echo "${CONTROLS%?}")
@@ -57,7 +57,7 @@ fi
 # Subcommands
 ARTIFACTS_PATH="/home/ks/.kubescape"
 FRAMEWORKS_CMD=$([ -n "$INPUT_FRAMEWORKS" ] && echo "framework $INPUT_FRAMEWORKS" || echo "")
-CONTROLS_CMD=$([ -n "$INPUT_CONTROLS" ] && echo control $CONTROLS || echo "")
+CONTROLS_CMD=$([ -n "$INPUT_CONTROLS" ] && echo control "${CONTROLS}" || echo "")
 
 # Files to scan
 FILES=$([ -n "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
@@ -66,14 +66,14 @@ FILES=$([ -n "$INPUT_FILES" ] && echo "$INPUT_FILES" || echo .)
 OUTPUT_FILE=$([ -n "$INPUT_OUTPUTFILE" ] && echo "$INPUT_OUTPUTFILE" || echo "results")
 
 # Command-line options
-ACCOUNT_OPT=$([ -n "$INPUT_ACCOUNT" ] && echo --account $INPUT_ACCOUNT || echo "")
+ACCOUNT_OPT=$([ -n "$INPUT_ACCOUNT" ] && echo --account "${INPUT_ACCOUNT}" || echo "")
 
 # If account ID is empty, we load artifacts from the local path, otherwise we
 # load from the cloud (this will enable custom framework support)
-ARTIFACTS=$([ -n "$INPUT_ACCOUNT" ] && echo "" || echo --use-artifacts-from $ARTIFACTS_PATH)
+ARTIFACTS=$([ -n "$INPUT_ACCOUNT" ] && echo "" || echo --use-artifacts-from "${ARTIFACTS_PATH}")
 
-FAIL_THRESHOLD_OPT=$([ -n "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold $INPUT_FAILEDTHRESHOLD || echo "")
-SEVERITY_THRESHOLD_OPT=$([ -n "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-threshold $INPUT_SEVERITYTHRESHOLD || echo "")
+FAIL_THRESHOLD_OPT=$([ -n "$INPUT_FAILEDTHRESHOLD" ] && echo --fail-threshold "${INPUT_FAILEDTHRESHOLD}" || echo "")
+SEVERITY_THRESHOLD_OPT=$([ -n "$INPUT_SEVERITYTHRESHOLD" ] && echo --severity-threshold "${INPUT_SEVERITYTHRESHOLD}" || echo "")
 
 # `kubescape fix` requires the latest "json" format version. Other formats
 # ignore this flag.
@@ -81,9 +81,9 @@ format_version_opt="--format-version v2"
 
 SCAN_COMMAND="kubescape scan $FRAMEWORKS_CMD $CONTROLS_CMD $FILES $ACCOUNT_OPT $FAIL_THRESHOLD_OPT $SEVERITY_THRESHOLD_OPT --format $INPUT_FORMAT $format_version_opt --output $OUTPUT_FILE"
 
-eval $SCAN_COMMAND
+eval "${SCAN_COMMAND}"
 
 if [ "$should_fix_files" = "true" ]; then
     fix_command="yes | kubescape fix $OUTPUT_FILE.json"
-    eval $fix_command
+    eval "${fix_command}"
 fi


### PR DESCRIPTION
# What this PR changes?

This change adds support for autofixing files. This is achieved by expanding the script that runs as the Docker entrypoint to run the `kubescape fix` command if a user requests it. It also validates that the prerequisites to fix the files are met: a scan must include a JSON output.

It also refactors the entry point script without breaking its functionality.