### PR TITLE
Support for code reviews instead with PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
     paths-ignore:
       - '**.md'
-      - '**/example.yaml'
+      - '**/example-*'
       - '*/examples/*'
 jobs:
 

--- a/.github/workflows/example-fix.yaml
+++ b/.github/workflows/example-fix.yaml
@@ -1,26 +1,3 @@
-name: Kubescape scanning for misconfigurations
-on: [push, pull_request]
-jobs:
-  kubescape:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: kubescape/github-action@main
-      continue-on-error: true
-      with:
-        format: sarif
-        outputFile: results.sarif
-        # Kubescape cloud account ID
-        account: ${{secrets.KUBESCAPE_ACCOUNT}}
-        # # Optional - Scan a specific path. Default will scan all
-        # files: "examples/*.yaml"
-    - name: Upload Kubescape scan results to Github Code Scanning
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        sarif_file: results.sarif
-
----
-
 name: Suggest autofixes with Kubescape
 on: [push, pull_request_target]
 

--- a/.github/workflows/example-fix.yaml
+++ b/.github/workflows/example-fix.yaml
@@ -2,7 +2,7 @@ name: Suggest autofixes with Kubescape
 on: [push, pull_request_target]
 
 jobs:
-  kubescape:
+  kubescape-fix:
     runs-on: ubuntu-latest
     permissions:
       # Needed only for "push" events
@@ -25,7 +25,6 @@ jobs:
       uses: tj-actions/changed-files@v35
     - uses: kubescape/github-action@main
       with:
-        account: ${{secrets.KUBESCAPE_ACCOUNT}}
         files: ${{ steps.changed-files.outputs.all_changed_files }}
         fixFiles: true
         format: "sarif"

--- a/.github/workflows/example-scan.yaml
+++ b/.github/workflows/example-scan.yaml
@@ -1,0 +1,20 @@
+name: Kubescape scanning for misconfigurations
+on: [push, pull_request]
+jobs:
+  kubescape:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: kubescape/github-action@main
+      continue-on-error: true
+      with:
+        format: sarif
+        outputFile: results.sarif
+        # Kubescape cloud account ID
+        account: ${{secrets.KUBESCAPE_ACCOUNT}}
+        # # Optional - Scan a specific path. Default will scan all
+        # files: "examples/*.yaml"
+    - name: Upload Kubescape scan results to Github Code Scanning
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: results.sarif

--- a/.github/workflows/example-scan.yaml
+++ b/.github/workflows/example-scan.yaml
@@ -1,7 +1,7 @@
 name: Kubescape scanning for misconfigurations
 on: [push, pull_request]
 jobs:
-  kubescape:
+  kubescape-scan:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -45,7 +45,7 @@ jobs:
         repository: ${{github.event.pull_request.head.repo.full_name}}
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v14.6
+      uses: tj-actions/changed-files@v35
     - uses: kubescape/github-action@main
       with:
         account: ${{secrets.KUBESCAPE_ACCOUNT}}
@@ -70,8 +70,21 @@ jobs:
         base: ${{ github.head_ref }}
         branch: kubescape-auto-fix-${{ github.head_ref || github.ref_name }}
         delete-branch: true
+    # # Alternatively, you can use reviewdog to replace the code-suggester
+    # - name: PR Suggester
+    #   if: github.event_name == 'pull_request_target'
+    #   uses: reviewdog/action-suggester@v1
+    #   with:
+    #     tool_name: Kubescape
+    - name: Clean up kubescape output
+      if: github.event_name == 'pull_request_target'
+      run: rm results.json results.sarif
     - name: PR Suggester
       if: github.event_name == 'pull_request_target'
-      uses: reviewdog/action-suggester@v1
+      uses: googleapis/code-suggester@v2
+      env:
+        ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tool_name: Kubescape
+        command: review
+        pull_number: ${{ github.event.pull_request.number }}
+        git_dir: '.'

--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -22,14 +22,27 @@ jobs:
 ---
 
 name: Suggest autofixes with Kubescape
-on: [pull_request]
+on: [push, pull_request_target]
+
 jobs:
   kubescape:
     runs-on: ubuntu-latest
+    permissions:
+      # Needed only for "push" events
+      contents: write
+      # Needed for both "push" and "pull_request_target" events
+      pull-requests: write
+
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - uses: actions/checkout@v3
+      if: github.event_name == 'pull_request_target'
+      with:
+        fetch-depth: 0
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
     - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@v14.6
@@ -40,6 +53,9 @@ jobs:
         fixFiles: true
         format: "sarif"
     - uses: peter-evans/create-pull-request@v4
+      # Remember to allow GitHub Actions to create and approve pull requests
+      # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests
+      if: github.event_name != 'pull_request_target'
       with:
         add-paths: |
           *.yaml
@@ -54,3 +70,8 @@ jobs:
         base: ${{ github.head_ref }}
         branch: kubescape-auto-fix-${{ github.head_ref || github.ref_name }}
         delete-branch: true
+    - name: PR Suggester
+      if: github.event_name == 'pull_request_target'
+      uses: reviewdog/action-suggester@v1
+      with:
+        tool_name: Kubescape


### PR DESCRIPTION
Now, the example workflow supports automatically suggest fixes to pushes by opening new PRs and pull requests by code review instead.

Check PRs at https://github.com/HollowMan6/test-kubescape-github-action/pulls for the tests I have down.