### PR TITLE
Add exceptions parameters back

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The next important thing to note is that Kubescape only fixes the files. It does
 | failedThreshold | Failure threshold is the percent above which the command fails and returns exit code 1 (default 0 i.e, action fails if any control fails) | No (default 0) |
 | severityThreshold | Severity threshold is the severity of a failed control at or above which the command terminates with an exit code 1 (default is `high`, i.e. the action fails if any High severity control fails) | No |
 | verbose | Display all of the input resources and not only failed resources. Default is off | No |
+| exceptions | The JSON file containing at least one resource and one policy. Refer [exceptions](https://hub.armo.cloud/docs/exceptions) docs for more info. Objects with exceptions will be presented as exclude and not fail. | No |
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
       Account ID for the Kubescape SaaS.
       Used for custom configuration, such as frameworks, control configuration, etc.
     required: false
+  exceptions:
+    description: |
+      Path to the json file containing exceptions.
+    required: false
   format:
     description: |
       Output format.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,6 +55,11 @@ if [ -n "${INPUT_VERBOSE}" ] && [ "${INPUT_VERBOSE}" != "false" ]; then
   verbose="--verbose"
 fi
 
+exceptions=""
+if [ -n "$INPUT_EXCEPTIONS" ]; then
+  exceptions="--exceptions ${INPUT_EXCEPTIONS}"
+fi
+
 should_fix_files="false"
 if [ "${INPUT_FIXFILES}" = "true" ]; then
   should_fix_files="true"
@@ -91,7 +96,7 @@ severity_threshold_opt=$(
 format_version_opt="--format-version v2"
 
 # TODO: include artifacts_opt once https://github.com/kubescape/kubescape/issues/1040 is resolved
-scan_command="kubescape scan ${frameworks_cmd} ${controls_cmd} ${files} ${account_opt} ${fail_threshold_opt} ${severity_threshold_opt} --format ${output_formats} ${format_version_opt} --output ${output_file} ${verbose}"
+scan_command="kubescape scan ${frameworks_cmd} ${controls_cmd} ${files} ${account_opt} ${fail_threshold_opt} ${severity_threshold_opt} --format ${output_formats} ${format_version_opt} --output ${output_file} ${verbose} ${exceptions}"
 
 echo "${scan_command}"
 eval "${scan_command}"


### PR DESCRIPTION
This PR adds exception parameter back.
- https://github.com/kubescape/github-action/pull/5

I don't know why it gets removed in commit https://github.com/kubescape/github-action/commit/f1e9a3c7ea803dfd0c74c594606adef83fc25e36

So would need confirmation by @Moshe-Rappaport-CA 