### PR TITLE
Add support for controls-config input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The next important thing to note is that Kubescape only fixes the files. It does
 | severityThreshold | Severity threshold is the severity of a failed control at or above which the command terminates with an exit code 1 (default is `high`, i.e. the action fails if any High severity control fails) | No |
 | verbose | Display all of the input resources and not only failed resources. Default is off | No |
 | exceptions | The JSON file containing at least one resource and one policy. Refer [exceptions](https://hub.armo.cloud/docs/exceptions) docs for more info. Objects with exceptions will be presented as exclude and not fail. | No |
-
+| controlsConfig | The file containing controls configuration. Use `kubescape download controls-inputs` to download the configured controls-inputs. | No |
 ## Examples
 
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
       Kubescape CLI to get a list of all controls. Either frameworks
       have to be specified or controls.
     required: false
+  controlsConfig:
+    description: |
+      Path to the file containing controls configuration.
+    required: false
   account:
     description: |
       Account ID for the Kubescape SaaS.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,9 +60,9 @@ if [ -n "$INPUT_EXCEPTIONS" ]; then
   exceptions="--exceptions ${INPUT_EXCEPTIONS}"
 fi
 
-controls-config=""
+controls_config=""
 if [ -n "$INPUT_CONTROLSCONFIG" ]; then
-  controls-config="--controls-config ${INPUT_CONTROLSCONFIG}"
+  controls_config="--controls-config ${INPUT_CONTROLSCONFIG}"
 fi
 
 should_fix_files="false"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,6 +60,11 @@ if [ -n "$INPUT_EXCEPTIONS" ]; then
   exceptions="--exceptions ${INPUT_EXCEPTIONS}"
 fi
 
+controls-config=""
+if [ -n "$INPUT_CONTROLSCONFIG" ]; then
+  controls-config="--controls-config ${INPUT_CONTROLSCONFIG}"
+fi
+
 should_fix_files="false"
 if [ "${INPUT_FIXFILES}" = "true" ]; then
   should_fix_files="true"
@@ -96,7 +101,7 @@ severity_threshold_opt=$(
 format_version_opt="--format-version v2"
 
 # TODO: include artifacts_opt once https://github.com/kubescape/kubescape/issues/1040 is resolved
-scan_command="kubescape scan ${frameworks_cmd} ${controls_cmd} ${files} ${account_opt} ${fail_threshold_opt} ${severity_threshold_opt} --format ${output_formats} ${format_version_opt} --output ${output_file} ${verbose} ${exceptions}"
+scan_command="kubescape scan ${frameworks_cmd} ${controls_cmd} ${files} ${account_opt} ${fail_threshold_opt} ${severity_threshold_opt} --format ${output_formats} ${format_version_opt} --output ${output_file} ${verbose} ${exceptions} ${controls-config}"
 
 echo "${scan_command}"
 eval "${scan_command}"


### PR DESCRIPTION
Related to the enhancement #39 

This PR enables users to specify the path for the controls configuration file, allowing flexibility in using kubescape with github-action

- Added controlsConfig input parameter to specify the file path for controls configuration
- Updated the script to include controls_config variable and check for the existence of controlsConfig input parameter to pass it as an argument to the Kubescape command
- Added description for controlsConfig input parameter in the action.yml file.
- Updated the documentation with the new input parameter
