### PR TITLE
Version bumps start PRs instead of committing directly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,9 @@
-name: Release with upstream
+name: Check release with upstream
 
 on:
   workflow_dispatch:  # Allow manual triggers
   push:
-    # Publish `v1.2.3` tags as releases.
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches: [ main ]
 
 env:
   BOT_NAME: "github-actions[bot]"
@@ -15,8 +13,8 @@ jobs:
   update:
     runs-on: ubuntu-latest
     permissions:
-      # Give the default GITHUB_TOKEN write permission to release, commit and push the changed files back to the repository.
       contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v3
     - name: Update repo
@@ -24,14 +22,26 @@ jobs:
         . ./update.sh
         echo "latest=${LATEST}" >> $GITHUB_ENV
         echo "current=${CURRENT}" >> $GITHUB_ENV
-    - uses: stefanzweifel/git-auto-commit-action@v4
+        git clone https://github.com/${{ github.repository }} github-action; cd github-action
+        export RELEASE=$(git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags || true)
+        rm -rf github-action
+        echo "release=${RELEASE}" >> $GITHUB_ENV
+    - uses: peter-evans/create-pull-request@v4
       if: env.latest != env.current
       with:
-        commit_author: "${{ env.BOT_NAME }} <${{ env.BOT_EMAIL }}>"
-        commit_message: Bump kubescape version into ${{ env.latest }}
+        add-paths: |
+          Dockerfile
+        commit-message: "Bump kubescape version into ${{ env.latest }}"
+        title: "[Kubescape] Bump kubescape version into ${{ env.latest }}"
+        body: |
+          # Overview
+          This PR bumps the kubescape version used in this action Docker image to the latest: ${{ env.latest }}
+        base: ${{ github.head_ref }}
+        branch: kubescape-bump-${{ env.latest }}-${{ github.head_ref || github.ref_name }}
+        delete-branch: true
     - name: Release
-      if: env.latest != env.current
+      if: env.release != env.current
       uses: softprops/action-gh-release@c9b46fe7aad9f02afd89b12450b780f52dacfb2d
       with:
-        tag_name: ${{ env.latest }}
-        body: Bump kubescape version into ${{ env.latest }}
+        tag_name: ${{ env.current }}
+        body: Bump kubescape version into ${{ env.current }}

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,6 @@
 git clone https://github.com/kubescape/kubescape.git --no-checkout
 cd kubescape
-export LATEST=$(git describe --tags --abbrev=0)
+export LATEST=$(git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags)
 cd ..
 rm -rf kubescape
 export CURRENT=$(cat Dockerfile | head -n1 | cut -d':' -f2)


### PR DESCRIPTION
This PR change the version bumping workflow into the follows to resolve
- https://github.com/kubescape/github-action/pull/38#issuecomment-1530022013

Now the workflow gets triggered by committing into main branch or manually.
- If any of the new release in the upstream is found, we start a new PR and get the docker image version bumped. 
- If the image version is bumped and no corresponding version tag is found in this repository, the workflow makes a new release for this action.