### PR TITLE
update README image scanning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The next important thing to note is that Kubescape only fixes the files. It does
 
 The Kubescape Github Action is also able to scan images. But you should be aware that image scanning cannot run in parallel with configuration scanning and file fixing at the moment. If you would like to run both image and configuration scanning, you should define at least two separate steps with the same action but different arguments: one for image scanning and the other for configuration scanning.
 
-To scan a container image with a Kubescape Github Action, use the following workflow definition, keeping in mind that you need to replace `image: "nginx"` with the appropriate image name:
+To scan a container image with a Kubescape Github Action, use the following workflow definition, keeping in mind that you need to replace `image: "quay.io/kubescape/kubescape"` with the appropriate image name:
 
 ```yaml
 name: Kubescape scanning for image vulnerabilities


### PR DESCRIPTION
## PR Type:
Documentation

___
## PR Description:
This PR updates the README documentation to correct the image scanning example. The previous version incorrectly stated to replace `image: "nginx"` with the appropriate image name. This has been corrected to `image: "quay.io/kubescape/kubescape"`.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`README.md`: The documentation for scanning images with Kubescape Github Action has been updated. The image name in the example has been corrected from `nginx` to `quay.io/kubescape/kubescape`.
</details>

___
## User Description:
The example uses `quay.io/kubescape/kubescape` as the image and not `nginx`. This PR updates the line mentioning to replace `image: "nginx"` since it is misleading.
