### PR TITLE
Scanning all frameworks by default

### DIFF
--- a/.github/workflows/example-fix-commit.yaml
+++ b/.github/workflows/example-fix-commit.yaml
@@ -20,7 +20,7 @@ jobs:
     - uses: kubescape/github-action@main
       with:
         account: ${{ secrets.KUBESCAPE_ACCOUNT }}
-        accessKey: ${{ secrets.KUBESCAPE_ACCESS_TOKEN }}
+        accessKey: ${{ secrets.KUBESCAPE_ACCESS_KEY }}
         server: ${{ vars.KUBESCAPE_SERVER }}
         files: ${{ steps.changed-files.outputs.all_changed_files }}
         fixFiles: true

--- a/.github/workflows/example-fix-pr-review.yaml
+++ b/.github/workflows/example-fix-pr-review.yaml
@@ -20,7 +20,7 @@ jobs:
     - uses: kubescape/github-action@main
       with:
         account: ${{secrets.KUBESCAPE_ACCOUNT}}
-        accessKey: ${{secrets.KUBESCAPE_ACCESS_TOKEN}}
+        accessKey: ${{secrets.KUBESCAPE_ACCESS_KEY}}
         server: ${{ vars.KUBESCAPE_SERVER }}
         files: ${{ steps.changed-files.outputs.all_changed_files }}
         fixFiles: true

--- a/.github/workflows/example-scan-image.yaml
+++ b/.github/workflows/example-scan-image.yaml
@@ -24,7 +24,7 @@ jobs:
         # # Fail at or above the specified vulnerability severity threshold
         # Kubescape Portal credentials
         # account: ${{secrets.KUBESCAPE_ACCOUNT}}
-        # accessKey: ${{secrets.KUBESCAPE_ACCESS_TOKEN}}
+        # accessKey: ${{secrets.KUBESCAPE_ACCESS_KEY}}
         # server: ${{ vars.KUBESCAPE_SERVER }}
     - name: Upload Kubescape scan results to Github Code Scanning
       uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/example-scan.yaml
+++ b/.github/workflows/example-scan.yaml
@@ -16,7 +16,7 @@ jobs:
         outputFile: results.sarif
         # Kubescape Portal credentials
         account: ${{secrets.KUBESCAPE_ACCOUNT}}
-        accessKey: ${{secrets.KUBESCAPE_ACCESS_TOKEN}}
+        accessKey: ${{secrets.KUBESCAPE_ACCESS_KEY}}
         server: ${{ vars.KUBESCAPE_SERVER }}
         # # Optional - Scan a specific path. Default will scan all
         # files: "examples/*.yaml"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,8 +25,8 @@ if [ -n "${INPUT_FRAMEWORKS}" ] && [ -n "${INPUT_CONTROLS}" ]; then
 fi
 
 if [ -z "${INPUT_FRAMEWORKS}" ] && [ -z "${INPUT_CONTROLS}" ] && [ -z "${INPUT_IMAGE}" ]; then
-  echo "Neither Framework, Control nor image are specified. Please specify one of them"
-  exit 1
+  echo "Scannign scope is not specified. Scanning all frameworks"
+  INPUT_FRAMEWORKS="all"
 fi
 
 


### PR DESCRIPTION
## **User description**
Fixes #61


___

## **Type**
bug_fix


___

## **Description**
- Updated the script to scan all frameworks by default when no specific framework, control, or image is specified.
- This change makes the tool more user-friendly by providing a sensible default behavior.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Default to Scanning All Frameworks on Empty Input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

entrypoint.sh
<li>Changed the behavior when no input is provided to scan all frameworks <br>by default.<br> <li> Updated the error message to reflect the new behavior.


</details>
    

  </td>
  <td><a href="https:/kubescape/github-action/pull/62/files#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

