### PR TITLE
feat: Implement dynamic Kubescape versioning in GitHub Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/kubescape/kubescape-cli:v3.0.21
+ARG KUBESCAPE_VERSION=v3.0.21
+FROM quay.io/kubescape/kubescape-cli:${KUBESCAPE_VERSION}
 
 # Kubescape uses root privileges for writing the results to a file
 USER root

--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,12 @@ inputs:
       use these fixes to open Pull Requests from your CI/CD pipeline.
     required: false
     default: "false"
+  version:
+    description: |
+      The version of Kubescape to use.
+
+      Can be a specific version (e.g. "v3.0.21") or "latest".
+    required: true
   image:
     description: |
       An image to scan.
@@ -111,7 +117,44 @@ inputs:
       A password for a private registry that contains the image to be scanned.
     required: false
 runs:
-  using: docker
-  image: Dockerfile
-  # image: docker://quay.io/kubescape/github-actions
-
+  using: 'composite'
+  steps:
+    - id: resolve_version
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        if [ "$VERSION" = "latest" ]; then
+          VERSION=$(curl -s -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/kubescape/kubescape/releases/latest | jq -r .tag_name)
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+    - name: Build Kubescape container
+      shell: bash
+      run: |
+        docker build -t kubescape-action:${{ steps.resolve_version.outputs.version }} \
+          --build-arg KUBESCAPE_VERSION=${{ steps.resolve_version.outputs.version }} \
+          ${{ github.action_path }}
+    - name: Run Kubescape scan
+      shell: bash
+      run: |
+        docker run --rm \
+          -v ${{ github.workspace }}:/scan \
+          -w /scan \
+          -e INPUT_FAILEDTHRESHOLD="${{ inputs.failedThreshold }}" \
+          -e INPUT_COMPLIANCETHRESHOLD="${{ inputs.complianceThreshold }}" \
+          -e INPUT_SEVERITYTHRESHOLD="${{ inputs.severityThreshold }}" \
+          -e INPUT_FILES="${{ inputs.files }}" \
+          -e INPUT_OUTPUTFILE="${{ inputs.outputFile }}" \
+          -e INPUT_VERBOSE="${{ inputs.verbose }}" \
+          -e INPUT_FRAMEWORKS="${{ inputs.frameworks }}" \
+          -e INPUT_CONTROLS="${{ inputs.controls }}" \
+          -e INPUT_CONTROLSCONFIG="${{ inputs.controlsConfig }}" \
+          -e INPUT_ACCOUNT="${{ inputs.account }}" \
+          -e INPUT_ACCESSKEY="${{ inputs.accessKey }}" \
+          -e INPUT_SERVER="${{ inputs.server }}" \
+          -e INPUT_EXCEPTIONS="${{ inputs.exceptions }}" \
+          -e INPUT_FORMAT="${{ inputs.format }}" \
+          -e INPUT_FIXFILES="${{ inputs.fixFiles }}" \
+          -e INPUT_IMAGE="${{ inputs.image }}" \
+          -e INPUT_REGISTRYUSERNAME="${{ inputs.registryUsername }}" \
+          -e INPUT_REGISTRYPASSWORD="${{ inputs.registryPassword }}" \
+          kubescape-action:${{ steps.resolve_version.outputs.version }}


### PR DESCRIPTION
## Why

Users should not have to wait for someone to update this action, which unfortunately happens very rarely, to benefit from updates to the main utility. We refactor the GitHub Action to build the Docker image at runtime using a user-specified version of `kubescape-cli`.

## What this does

* Introduce a build argument `KUBESCAPE_VERSION` in the `Dockerfile` to dynamically set the base image version.
* Convert the action to a composite action in `action.yml`.
* Add a mandatory `version` input to `action.yml` to allow users to specify any `kubescape-cli` version or 'latest'.
* Implement version resolution logic in `action.yml` to fetch the latest tag if `version` is set to 'latest', using the `github.token` for authentication.
* Update the build step in `action.yml` to pass the resolved version as the `--build-arg KUBESCAPE_VERSION` to `docker build`.
* Update the run step in `action.yml` to use the resolved version tag for the `docker run` command.
* Rewrite `update.sh` to fetch the latest release tag and update the `KUBESCAPE_VERSION` argument in the `Dockerfile` using `sed`.

## Testing

I successfully ran [the refactored action](https://github.com/esafak/kubescape-gha/blob/main/.github/workflows/example-scan.yaml) on my fork: https://github.com/esafak/kubescape-gha/actions/runs/20386459620/job/58588241646

## Notes

The `kubescape-fix-pr-reviews` workflow, which I did not touch, fails with the **typo** "Scannign scope is not specified. Scanning all frameworks".