### PR TITLE
fix: make version input optional with default 'latest'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,8 @@ inputs:
       The version of Kubescape to use.
 
       Can be a specific version (e.g. "v3.0.21") or "latest".
-    required: true
+    required: false
+    default: "latest"
   image:
     description: |
       An image to scan.


### PR DESCRIPTION
## Problem

Commit b2454fb091659d90a4dadfe5c5aabd7ce55de064 introduced a breaking change by making the `version` input **required** without:
1. Updating the documentation/README examples
2. Providing a default value

This breaks all existing workflows that don't specify a version, including:
- https://github.com/kubescape/helm-charts/actions/runs/20901149827/job/60047207893?pr=779
- https://github.com/kubescape/github-action/actions/runs/20900966237/job/60046717822

## Solution

Make `version` optional with a default of `"latest"` to restore backward compatibility.

## Changes

```diff
  version:
    description: |
      The version of Kubescape to use.

      Can be a specific version (e.g. "v3.0.21") or "latest".
-   required: true
+   required: false
+   default: "latest"
```

## Behavior

- **Existing workflows** (without `version`): Will now automatically use the latest kubescape release
- **New workflows** (with explicit `version`): Continue to work as expected with their specified version