### PR TITLE
fix: Specify mandatory version property for Kubescape action in examples

### DIFF
--- a/.github/workflows/example-fix-commit.yaml
+++ b/.github/workflows/example-fix-commit.yaml
@@ -19,6 +19,7 @@ jobs:
       uses: tj-actions/changed-files@v35
     - uses: kubescape/github-action@main
       with:
+        version: latest
         account: ${{ secrets.KUBESCAPE_ACCOUNT }}
         accessKey: ${{ secrets.KUBESCAPE_ACCESS_KEY }}
         server: ${{ vars.KUBESCAPE_SERVER }}

--- a/.github/workflows/example-fix-pr-review.yaml
+++ b/.github/workflows/example-fix-pr-review.yaml
@@ -19,8 +19,9 @@ jobs:
       uses: tj-actions/changed-files@v35
     - uses: kubescape/github-action@main
       with:
+        version: latest
         account: ${{secrets.KUBESCAPE_ACCOUNT}}
-        accessKey: ${{secrets.KUBESCAPE_ACCESS_KEY}}
+        accessKey: ${{ secrets.KUBESCAPE_ACCESS_KEY }}
         server: ${{ vars.KUBESCAPE_SERVER }}
         files: ${{ steps.changed-files.outputs.all_changed_files }}
         fixFiles: true

--- a/.github/workflows/example-scan-image.yaml
+++ b/.github/workflows/example-scan-image.yaml
@@ -12,6 +12,7 @@ jobs:
     - uses: kubescape/github-action@main
       continue-on-error: true
       with:
+        version: latest
         image: quay.io/kubescape/kubescape:v3.0.3
         format: sarif
         outputFile: results.sarif

--- a/.github/workflows/example-scan.yaml
+++ b/.github/workflows/example-scan.yaml
@@ -12,6 +12,7 @@ jobs:
     - uses: kubescape/github-action@main
       continue-on-error: true
       with:
+        version: latest
         format: sarif
         outputFile: results.sarif
         # Kubescape Portal credentials

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ if [ -n "${INPUT_FRAMEWORKS}" ] && [ -n "${INPUT_CONTROLS}" ]; then
 fi
 
 if [ -z "${INPUT_FRAMEWORKS}" ] && [ -z "${INPUT_CONTROLS}" ] && [ -z "${INPUT_IMAGE}" ]; then
-  echo "Scannign scope is not specified. Scanning all frameworks"
+  echo "Scanning scope is not specified. Scanning all frameworks"
   INPUT_FRAMEWORKS="all"
 fi
 


### PR DESCRIPTION
## Why

#72 broke the existing workflows because we neglected to update them to specify the new, **mandatory** `version` property.

## This PR will...

* Add `version: latest` input to `.github/workflows/example-scan.yaml`.
* Add `version: latest` input to `.github/workflows/example-scan-image.yaml`.
* Add `version: latest` input to `.github/workflows/example-fix-commit.yaml`.
* Add `version: latest` input to `.github/workflows/example-fix-pr-review.yaml`.
* Correct typo "Scannign" to "Scanning" in `entrypoint.sh`.

## Notes

Since this is a breaking change, I suggest versioning and updating documentation accordingly.