### PR TITLE
docs: specify version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ jobs:
 
 ## Examples
 
+> **Note:** The `version` input defaults to `latest`, so it is omitted from the examples below. For reproducible scans, pin a specific Kubescape release with e.g. `version: v3.0.21`.
 
 #### Scan and submit results to the [Kubescape Cloud](https://cloud.armosec.io/)
 


### PR DESCRIPTION
Small doc PR specifying version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `version` input defaults to `latest`
  * Added guidance on pinning specific release versions for reproducible scans

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/github-action/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->